### PR TITLE
[codex] Fix PR 48 OCR review issues

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,8 @@
 // Service worker that caches the large OCR assets (WASM binary, .rten
 // models, brand list) so repeat visits load instantly and the app keeps
 // working on flaky in-store connections.
-const CACHE_NAME = "fnc-ocr-assets-v1"
+const CACHE_PREFIX = "fnc-ocr-assets-"
+const CACHE_NAME = `${CACHE_PREFIX}v2`
 const PRECACHE_PATHS = [
   "/ocrs_bg.wasm",
   "/text-detection.rten",
@@ -25,10 +26,36 @@ async function cacheFirst(request) {
     return cached
   }
   const response = await fetch(request)
-  if (response.ok) {
-    await cache.put(request, response.clone())
-  }
+  await cacheResponse(cache, request, response)
   return response
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(CACHE_NAME)
+  const cached = await cache.match(request)
+  const networkResponse = fetch(request)
+    .then(async (response) => {
+      await cacheResponse(cache, request, response)
+      return response
+    })
+    .catch((error) => {
+      if (!cached) {
+        throw error
+      }
+      console.error("Failed to revalidate cached OCR asset:", request.url, error)
+      return cached
+    })
+  return cached || networkResponse
+}
+
+async function cacheResponse(cache, request, response) {
+  if (response.ok) {
+    try {
+      await cache.put(request, response.clone())
+    } catch (error) {
+      console.error("Failed to cache OCR asset:", request.url, error)
+    }
+  }
 }
 
 self.addEventListener("install", (event) => {
@@ -39,10 +66,7 @@ self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
       .open(CACHE_NAME)
-      .then((cache) => cache.addAll(PRECACHE_PATHS))
-      .catch((error) => {
-        console.error("Precaching OCR assets failed:", error)
-      }),
+      .then((cache) => cache.addAll(PRECACHE_PATHS)),
   )
 })
 
@@ -52,7 +76,7 @@ self.addEventListener("activate", (event) => {
       const names = await caches.keys()
       await Promise.all(
         names
-          .filter((name) => name !== CACHE_NAME)
+          .filter((name) => name.startsWith(CACHE_PREFIX) && name !== CACHE_NAME)
           .map((name) => caches.delete(name)),
       )
       await self.clients.claim()
@@ -66,6 +90,10 @@ self.addEventListener("fetch", (event) => {
   }
   const url = new URL(event.request.url)
   if (isCacheableAsset(url)) {
-    event.respondWith(cacheFirst(event.request))
+    event.respondWith(
+      url.pathname === "/brands.json"
+        ? staleWhileRevalidate(event.request)
+        : cacheFirst(event.request),
+    )
   }
 })

--- a/src/components/mobile-camera-view.tsx
+++ b/src/components/mobile-camera-view.tsx
@@ -23,6 +23,8 @@ const TARGET_ROI_WIDTH = 640
 const FRAME_PACING_MS = 100
 /** Poll interval while detection is paused or the pipeline is not ready. */
 const IDLE_POLL_MS = 250
+/** Maximum age for a match box to stay spatially attached to the camera feed. */
+const RECENT_MATCH_MS = 300
 
 type CameraStatus = "starting" | "active" | "denied" | "unavailable" | "error"
 type OcrStatus = "loading" | "ready" | "error"
@@ -132,6 +134,7 @@ function drawOverlay(
   videoHeight: number,
   roi: Roi,
   matches: readonly ConfirmedBrand[],
+  now: number,
 ): void {
   if (canvas.width !== videoWidth) {
     canvas.width = videoWidth
@@ -154,7 +157,9 @@ function drawOverlay(
   const fontSize = Math.max(16, Math.round(videoWidth / 40))
   ctx.font = `bold ${fontSize}px sans-serif`
   for (const match of matches) {
-    drawMatchLabel(ctx, match, fontSize)
+    if (now - match.lastSeenAt <= RECENT_MATCH_MS) {
+      drawMatchLabel(ctx, match, fontSize)
+    }
   }
 }
 
@@ -203,6 +208,7 @@ export function MobileCameraView() {
   const matcherRef = useRef<BrandMatcher | null>(null)
   const voterRef = useRef(new TemporalVoter())
   const detectionActiveRef = useRef(true)
+  const cameraRequestRef = useRef(0)
 
   useEffect(() => {
     if ("serviceWorker" in navigator) {
@@ -213,7 +219,17 @@ export function MobileCameraView() {
   }, [])
 
   useEffect(() => {
-    const client = new OcrClient()
+    let cancelled = false
+    let client: OcrClient
+    try {
+      client = new OcrClient()
+    } catch (error) {
+      console.error("OCR initialization failed:", error)
+      setOcrStatus("error")
+      return () => {
+        cancelled = true
+      }
+    }
     ocrClientRef.current = client
 
     const loadBrands = async () => {
@@ -222,32 +238,50 @@ export function MobileCameraView() {
         throw new Error(`HTTP error fetching brands: ${response.status}`)
       }
       const { brands } = (await response.json()) as { brands: string[] }
-      matcherRef.current = new BrandMatcher(brands)
+      if (!cancelled) {
+        matcherRef.current = new BrandMatcher(brands)
+      }
     }
 
     Promise.all([client.readyPromise, loadBrands()])
-      .then(() => setOcrStatus("ready"))
+      .then(() => {
+        if (!cancelled) {
+          setOcrStatus("ready")
+        }
+      })
       .catch((error) => {
-        console.error("OCR initialization failed:", error)
-        setOcrStatus("error")
+        if (!cancelled) {
+          console.error("OCR initialization failed:", error)
+          setOcrStatus("error")
+        }
       })
 
     return () => {
+      cancelled = true
       ocrClientRef.current = null
+      matcherRef.current = null
       client.dispose()
     }
   }, [])
 
   const stopStream = useCallback(() => {
+    cameraRequestRef.current += 1
     for (const track of streamRef.current?.getTracks() ?? []) {
       track.stop()
     }
     streamRef.current = null
+    if (videoRef.current) {
+      videoRef.current.srcObject = null
+    }
   }, [])
 
   const startCamera = useCallback(async () => {
     stopStream()
+    const requestId = ++cameraRequestRef.current
     setCameraStatus("starting")
+    if (document.hidden) {
+      return
+    }
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: {
@@ -256,14 +290,22 @@ export function MobileCameraView() {
           height: { ideal: 720 },
         },
       })
+      if (requestId !== cameraRequestRef.current || document.hidden) {
+        for (const track of stream.getTracks()) {
+          track.stop()
+        }
+        return
+      }
       streamRef.current = stream
       if (videoRef.current) {
         videoRef.current.srcObject = stream
       }
       setCameraStatus("active")
     } catch (error) {
-      console.error("Error accessing the camera:", error)
-      setCameraStatus(statusFromCameraError(error))
+      if (requestId === cameraRequestRef.current && !document.hidden) {
+        console.error("Error accessing the camera:", error)
+        setCameraStatus(statusFromCameraError(error))
+      }
     }
   }, [facingMode, stopStream])
 
@@ -330,9 +372,10 @@ export function MobileCameraView() {
       ...match,
       rect: mapRectToVideo(match.rect, roi),
     }))
-    const confirmed = voterRef.current.addFrame(matches, Date.now())
+    const now = Date.now()
+    const confirmed = voterRef.current.addFrame(matches, now)
     setConfirmedBrands(confirmed)
-    drawOverlay(overlay, video.videoWidth, video.videoHeight, roi, confirmed)
+    drawOverlay(overlay, video.videoWidth, video.videoHeight, roi, confirmed, now)
     return true
   }, [])
 
@@ -368,6 +411,7 @@ export function MobileCameraView() {
     <div className="flex w-full max-w-md flex-col items-center gap-4">
       <div className="relative aspect-[3/4] w-full overflow-hidden rounded-lg bg-black shadow-lg">
         <video
+          aria-hidden="true"
           muted={true}
           ref={videoRef}
           autoPlay={true}

--- a/src/lib/brand-matcher.ts
+++ b/src/lib/brand-matcher.ts
@@ -68,20 +68,26 @@ export class BrandMatcher {
     { returnMatchData: true; threshold: number }
   >
   private readonly exactBrands = new Map<string, string>()
+  private readonly fuzzyBrands = new Map<string, string>()
+  private readonly maxBrandWords: number
 
   constructor(brands: string[]) {
     const fuzzyBrands: string[] = []
+    let maxBrandWords = 1
     for (const brand of brands) {
       const normalized = normalizeText(brand)
       if (normalized.length === 0) {
         continue
       }
+      maxBrandWords = Math.max(maxBrandWords, normalized.split(" ").length)
       if (normalized.length <= SHORT_BRAND_MAX_LENGTH) {
         this.exactBrands.set(normalized, brand)
       } else {
-        fuzzyBrands.push(brand)
+        fuzzyBrands.push(normalized)
+        this.fuzzyBrands.set(normalized, brand)
       }
     }
+    this.maxBrandWords = Math.min(maxBrandWords, MAX_WINDOW_WORDS)
     this.searcher = new Searcher(fuzzyBrands, {
       returnMatchData: true,
       threshold: FUZZY_THRESHOLD,
@@ -102,9 +108,9 @@ export class BrandMatcher {
     if (exact) {
       this.record(results, { brand: exact, score: 1, sourceText: text, rect })
     }
-    for (const match of this.searcher.search(text)) {
+    for (const match of this.searcher.search(normalized)) {
       this.record(results, {
-        brand: match.item,
+        brand: this.fuzzyBrands.get(match.item) ?? match.item,
         score: match.score,
         sourceText: text,
         rect,
@@ -130,7 +136,7 @@ export class BrandMatcher {
       const plausibleWords = line.words.filter((word) =>
         isPlausibleWord(word.text),
       )
-      for (let size = 1; size <= MAX_WINDOW_WORDS; size++) {
+      for (let size = 1; size <= this.maxBrandWords; size++) {
         for (let start = 0; start + size <= plausibleWords.length; start++) {
           const window = plausibleWords.slice(start, start + size)
           this.matchText(

--- a/src/lib/temporal-voter.ts
+++ b/src/lib/temporal-voter.ts
@@ -30,7 +30,7 @@ export class TemporalVoter {
     for (const match of matches) {
       this.lastMatch.set(match.brand, { ...match, lastSeenAt: now })
     }
-    this.promoteWinners(now)
+    this.promoteWinners(matches, now)
     this.evictExpired(now)
     return Array.from(this.confirmedUntil.keys())
       .map((brand) => this.lastMatch.get(brand))
@@ -44,7 +44,8 @@ export class TemporalVoter {
     this.confirmedUntil.clear()
   }
 
-  private promoteWinners(now: number): void {
+  private promoteWinners(matches: BrandMatch[], now: number): void {
+    const currentFrame = new Set(matches.map((match) => match.brand))
     const hits = new Map<string, number>()
     for (const frame of this.frames) {
       for (const brand of frame) {
@@ -52,7 +53,7 @@ export class TemporalVoter {
       }
     }
     for (const [brand, count] of hits) {
-      if (count >= VOTE_MIN_HITS) {
+      if (count >= VOTE_MIN_HITS && currentFrame.has(brand)) {
         this.confirmedUntil.set(brand, now + DISPLAY_TTL_MS)
       }
     }

--- a/src/ocr/ocr-client.ts
+++ b/src/ocr/ocr-client.ts
@@ -16,28 +16,38 @@ export class OcrClient {
   private readonly pending = new Map<number, PendingRequest>()
   private nextId = 0
   private ready = false
+  private disposed = false
+  private readySettled = false
+  private resolveReady: (() => void) | null = null
+  private rejectReady: ((error: Error) => void) | null = null
   readonly readyPromise: Promise<void>
 
   constructor() {
-    this.worker = new Worker(new URL("./ocr-worker.ts", import.meta.url))
+    this.worker = new Worker(new URL("./ocr-worker.ts", import.meta.url), {
+      type: "module",
+    })
     this.readyPromise = new Promise((resolve, reject) => {
+      this.resolveReady = resolve
+      this.rejectReady = reject
       this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+        if (this.disposed) {
+          return
+        }
         const message = event.data
         if (message.type === "ready") {
-          this.ready = true
-          resolve()
+          this.settleReady()
           return
         }
         if (message.type === "init-error") {
-          reject(new Error(message.message))
+          this.failWorker(new Error(message.message))
           return
         }
         this.settle(message)
       }
-      this.worker.onerror = (event) => {
-        reject(new Error(event.message || "OCR worker failed to load"))
-      }
     })
+    this.worker.onerror = (event) => {
+      this.failWorker(new Error(event.message || "OCR worker failed"))
+    }
   }
 
   get isReady(): boolean {
@@ -59,7 +69,46 @@ export class OcrClient {
     }
   }
 
+  private settleReady(): void {
+    if (this.readySettled) {
+      return
+    }
+    this.ready = true
+    this.readySettled = true
+    this.resolveReady?.()
+    this.resolveReady = null
+    this.rejectReady = null
+  }
+
+  private rejectReadiness(error: Error): void {
+    if (this.readySettled) {
+      return
+    }
+    this.readySettled = true
+    this.rejectReady?.(error)
+    this.resolveReady = null
+    this.rejectReady = null
+  }
+
+  private failPending(error: Error): void {
+    for (const request of this.pending.values()) {
+      request.reject(error)
+    }
+    this.pending.clear()
+  }
+
+  private failWorker(error: Error): void {
+    this.ready = false
+    this.disposed = true
+    this.rejectReadiness(error)
+    this.failPending(error)
+    this.worker.terminate()
+  }
+
   detect(imageData: ImageData): Promise<DetectResult> {
+    if (this.disposed) {
+      return Promise.reject(new Error("OCR client is disposed"))
+    }
     const id = this.nextId++
     const request: DetectRequest = {
       id,
@@ -70,15 +119,23 @@ export class OcrClient {
     }
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject })
-      this.worker.postMessage(request, [request.pixels])
+      try {
+        this.worker.postMessage(request, [request.pixels])
+      } catch (error) {
+        this.pending.delete(id)
+        reject(error instanceof Error ? error : new Error(String(error)))
+      }
     })
   }
 
   dispose(): void {
-    this.worker.terminate()
-    for (const request of this.pending.values()) {
-      request.reject(new Error("OCR client disposed"))
+    if (this.disposed) {
+      return
     }
-    this.pending.clear()
+    this.disposed = true
+    this.worker.terminate()
+    const error = new Error("OCR client disposed")
+    this.rejectReadiness(error)
+    this.failPending(error)
   }
 }

--- a/src/ocr/ocr-worker.ts
+++ b/src/ocr/ocr-worker.ts
@@ -10,6 +10,11 @@ import {
 } from "../ocrs/ocrs.js"
 import type { DetectRequest, OcrLine, WorkerResponse } from "./protocol"
 
+const workerSelf = self as unknown as {
+  onmessage: ((event: MessageEvent<DetectRequest>) => Promise<void>) | null
+  postMessage(message: WorkerResponse): void
+}
+
 /**
  * Frames whose variance-of-Laplacian falls below this are considered too
  * blurry (camera in motion / hunting focus) to be worth an inference pass.
@@ -111,13 +116,17 @@ function stretchContrast(gray: Uint8Array): void {
   let cumulative = 0
   let low = 0
   let high = MAX_LUMA
+  let lowFound = false
+  let highFound = false
   for (let value = 0; value <= MAX_LUMA; value++) {
     cumulative += histogram[value]
-    if (cumulative <= lowTarget) {
+    if (!lowFound && cumulative >= lowTarget) {
       low = value
+      lowFound = true
     }
-    if (cumulative < highTarget) {
+    if (!highFound && cumulative >= highTarget) {
       high = value
+      highFound = true
     }
   }
   if (high <= low) {
@@ -149,21 +158,42 @@ function recognizeLines(
 ): OcrLine[] {
   const image = engine.loadImage(width, height, rgb)
   try {
-    return engine.getTextLines(image).map((line) => ({
-      text: line.text(),
-      words: line.words().map((word) => {
-        const rect = word.rotatedRect().boundingRect()
-        return {
-          text: word.text(),
-          rect: [rect[0], rect[1], rect[2], rect[3]] as [
-            number,
-            number,
-            number,
-            number,
-          ],
+    const lines = engine.getTextLines(image)
+    try {
+      return lines.map((line) => {
+        const words = line.words()
+        try {
+          return {
+            text: line.text(),
+            words: words.map((word) => {
+              const rotatedRect = word.rotatedRect()
+              try {
+                const rect = rotatedRect.boundingRect()
+                return {
+                  text: word.text(),
+                  rect: [rect[0], rect[1], rect[2], rect[3]] as [
+                    number,
+                    number,
+                    number,
+                    number,
+                  ],
+                }
+              } finally {
+                rotatedRect.free()
+              }
+            }),
+          }
+        } finally {
+          for (const word of words) {
+            word.free()
+          }
         }
-      }),
-    }))
+      })
+    } finally {
+      for (const line of lines) {
+        line.free()
+      }
+    }
   } finally {
     image.free()
   }
@@ -192,12 +222,12 @@ function handleDetect(request: DetectRequest): WorkerResponse {
 
 const initPromise = initEngine()
 
-self.onmessage = async (event: MessageEvent<DetectRequest>) => {
+workerSelf.onmessage = async (event: MessageEvent<DetectRequest>) => {
   const request = event.data
   try {
     await initPromise
   } catch (error) {
-    self.postMessage({
+    workerSelf.postMessage({
       type: "detect-error",
       id: request.id,
       message: `OCR init failed: ${String(error)}`,
@@ -205,9 +235,9 @@ self.onmessage = async (event: MessageEvent<DetectRequest>) => {
     return
   }
   try {
-    self.postMessage(handleDetect(request))
+    workerSelf.postMessage(handleDetect(request))
   } catch (error) {
-    self.postMessage({
+    workerSelf.postMessage({
       type: "detect-error",
       id: request.id,
       message: String(error),
@@ -216,9 +246,11 @@ self.onmessage = async (event: MessageEvent<DetectRequest>) => {
 }
 
 initPromise
-  .then(() => self.postMessage({ type: "ready" } satisfies WorkerResponse))
+  .then(() =>
+    workerSelf.postMessage({ type: "ready" } satisfies WorkerResponse),
+  )
   .catch((error) =>
-    self.postMessage({
+    workerSelf.postMessage({
       type: "init-error",
       message: String(error),
     } satisfies WorkerResponse),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/ocr/ocr-worker.ts"]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "incremental": false,
+    "lib": ["webworker", "esnext"],
+    "types": []
+  },
+  "include": [
+    "src/ocr/ocr-worker.ts",
+    "src/ocr/protocol.ts",
+    "src/ocrs/ocrs.d.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

Fixes the actionable review feedback from PR #48 around OCR worker lifecycle handling, camera stream races, service-worker caching, brand matching, and temporal overlay behavior.

## What changed

- Hardened `OcrClient` so worker startup/runtime failures, disposal, and synchronous `postMessage` failures settle readiness and pending detection promises instead of hanging.
- Guarded camera acquisition with request tokens, hidden-tab checks, and explicit `video.srcObject` cleanup.
- Updated the service worker cache strategy to avoid stale `brands.json`, tolerate cache write failures after successful fetches, fail install on precache failure, and delete only this app's cache namespace.
- Fixed contrast percentile selection, explicitly freed OCR WASM wrapper objects, normalized fuzzy brand matching, capped fuzzy search windows, and prevented stale bounding boxes.
- Added worker-specific TypeScript checking through `tsconfig.worker.json`.

## Root cause

The Web Worker OCR refactor introduced async boundaries that were not fully lifecycle-aware: worker crashes and disposal could leave promises unresolved, overlapping camera starts could attach stale streams, and cache-first model assets could remain stale across deploys.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npx tsc -p tsconfig.worker.json --noEmit`
- `npm run build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/fuck-nestle-camera/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

